### PR TITLE
Different versions of Facebook .json files

### DIFF
--- a/src/activities/facebook/device_location.rs
+++ b/src/activities/facebook/device_location.rs
@@ -20,33 +20,41 @@ pub struct DeviceLocation {
 #[allow(non_snake_case)]
 impl DeviceLocation {
     pub fn saveToDb(&self, conn: &Connection) -> Result<(), rusqlite::Error> {
-        match &self.phone_number_location_v2 {
-            None => None,
-            Some(x) => Some(for elem in x.iter() {
-                let my_uuid = Uuid::new_v4();
+        match &self.location_history_v2 {
+            Some(x) => x.iter().for_each(|elem| {
                 conn.execute(
-                    "INSERT into facebook_device_location
-                                (uuid, spn, country_code)
-                                VALUES (?1, $2, $3)",
-                    params![&my_uuid.to_string(), elem.spn, elem.country_code,],
+                    "INSERT into facebook_location_history
+                    (time, name, latitude, longitude)
+                    values(?1, $2, $3, $4)",
+                    params![
+                        elem.creation_timestamp.to_string(),
+                        elem.name,
+                        elem.coordinate.latitude.to_string(),
+                        elem.coordinate.longitude.to_string()
+                    ],
                 )
                 .map_err(|err| println!("{:?}", err))
                 .ok();
             }),
+            None => println!("Old version of Facebook's data"),
         };
-        match &self.phone_number_location {
-            None => None,
-            Some(x) => Some(for elem in x.iter() {
-                let my_uuid = Uuid::new_v4();
+        match &self.location_history {
+            Some(x) => x.iter().for_each(|elem| {
                 conn.execute(
-                    "INSERT into facebook_device_location
-                                (uuid, spn, country_code)
-                                values(?1, $2, $3)",
-                    params![&my_uuid.to_string(), elem.spn, elem.country_code,],
+                    "INSERT into facebook_location_history
+                    (time, name, latitude, longitude)
+                    values(?1, $2, $3, $4)",
+                    params![
+                        elem.creation_timestamp.to_string(),
+                        elem.name,
+                        elem.coordinate.latitude.to_string(),
+                        elem.coordinate.longitude.to_string()
+                    ],
                 )
                 .map_err(|err| println!("{:?}", err))
                 .ok();
             }),
+            None => println!("Current version of Facebook's data"),
         };
         Ok(())
     }

--- a/src/activities/facebook/device_location.rs
+++ b/src/activities/facebook/device_location.rs
@@ -20,46 +20,37 @@ pub struct DeviceLocation {
 #[allow(non_snake_case)]
 impl DeviceLocation {
     pub fn saveToDb(&self, conn: &Connection) -> Result<(), rusqlite::Error> {
-        match &self.location_history_v2 {
-            Some(x) => x.iter().for_each(|elem| {
+        match &self.phone_number_location_v2 {
+            None => None,
+            Some(x) => Some(for elem in x.iter() {
+                let my_uuid = Uuid::new_v4();
                 conn.execute(
-                    "INSERT into facebook_location_history
-                    (time, name, latitude, longitude)
-                    values(?1, $2, $3, $4)",
-                    params![
-                        elem.creation_timestamp.to_string(),
-                        elem.name,
-                        elem.coordinate.latitude.to_string(),
-                        elem.coordinate.longitude.to_string()
-                    ],
+                    "INSERT into facebook_device_location
+                                (uuid, spn, country_code)
+                                VALUES (?1, $2, $3)",
+                    params![&my_uuid.to_string(), elem.spn, elem.country_code,],
                 )
                 .map_err(|err| println!("{:?}", err))
                 .ok();
             }),
-            None => println!("Old version of Facebook's data"),
         };
-        match &self.location_history {
-            Some(x) => x.iter().for_each(|elem| {
+        match &self.phone_number_location {
+            None => None,
+            Some(x) => Some(for elem in x.iter() {
+                let my_uuid = Uuid::new_v4();
                 conn.execute(
-                    "INSERT into facebook_location_history
-                    (time, name, latitude, longitude)
-                    values(?1, $2, $3, $4)",
-                    params![
-                        elem.creation_timestamp.to_string(),
-                        elem.name,
-                        elem.coordinate.latitude.to_string(),
-                        elem.coordinate.longitude.to_string()
-                    ],
+                    "INSERT into facebook_device_location
+                                (uuid, spn, country_code)
+                                values(?1, $2, $3)",
+                    params![&my_uuid.to_string(), elem.spn, elem.country_code,],
                 )
                 .map_err(|err| println!("{:?}", err))
                 .ok();
             }),
-            None => println!("Current version of Facebook's data"),
         };
         Ok(())
     }
 }
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/activities/facebook/device_location.rs
+++ b/src/activities/facebook/device_location.rs
@@ -13,24 +13,41 @@ pub struct CellPhoneCarrier {
 #[allow(non_snake_case)]
 #[derive(Deserialize, Debug)]
 pub struct DeviceLocation {
-  pub phone_number_location_v2: Vec<CellPhoneCarrier>
+  pub phone_number_location_v2: Option<Vec<CellPhoneCarrier>>,
+  pub phone_number_location: Option<Vec<CellPhoneCarrier>>
 }
 
 #[allow(non_snake_case)]
 impl DeviceLocation {
     pub fn saveToDb(&self, conn: &Connection) -> Result<(), rusqlite::Error> {
-        for elem in self.phone_number_location_v2.iter() {
-            let my_uuid = Uuid::new_v4();
-            conn.execute(
-                "INSERT into facebook_device_location
-                (uuid, spn, country_code)
-                values(?1, $2, $3)",
-                params![&my_uuid.to_string(), elem.spn, elem.country_code,],
-            )
-            .map_err(|err| println!("{:?}", err))
-            .ok();
-        }
-
+        match &self.phone_number_location_v2 {
+            None => None,
+            Some(x) => Some(for elem in x.iter() {
+                let my_uuid = Uuid::new_v4();
+                conn.execute(
+                    "INSERT into facebook_device_location
+                                (uuid, spn, country_code)
+                                VALUES (?1, $2, $3)",
+                    params![&my_uuid.to_string(), elem.spn, elem.country_code,],
+                )
+                .map_err(|err| println!("{:?}", err))
+                .ok();
+            }),
+        };
+        match &self.phone_number_location {
+            None => None,
+            Some(x) => Some(for elem in x.iter() {
+                let my_uuid = Uuid::new_v4();
+                conn.execute(
+                    "INSERT into facebook_device_location
+                                (uuid, spn, country_code)
+                                values(?1, $2, $3)",
+                    params![&my_uuid.to_string(), elem.spn, elem.country_code,],
+                )
+                .map_err(|err| println!("{:?}", err))
+                .ok();
+            }),
+        };
         Ok(())
     }
 }
@@ -41,6 +58,21 @@ mod tests {
     use rusqlite::Connection;
 
     #[test]
+    fn test_device_location_v2() -> Result<(), Box<dyn std::error::Error>> {
+        let conn = Connection::open("ichnion.db")?;
+        let cell_phone_carrier = CellPhoneCarrier {
+            spn: "NTT DoCoMo".to_string(),
+            country_code: "440".to_string(),
+        };
+        let device_location = DeviceLocation {
+            phone_number_location_v2: Some(vec![cell_phone_carrier]),
+            phone_number_location: None,
+        };
+        let result = DeviceLocation::saveToDb(&device_location, &conn);
+        assert_eq!(result, Ok(()));
+        Ok(())
+    }
+    #[test]
     fn test_device_location() -> Result<(), Box<dyn std::error::Error>> {
         let conn = Connection::open("ichnion.db")?;
         let cell_phone_carrier = CellPhoneCarrier {
@@ -48,7 +80,8 @@ mod tests {
             country_code: "440".to_string(),
         };
         let device_location = DeviceLocation {
-            phone_number_location_v2: vec![cell_phone_carrier],
+            phone_number_location_v2: None,
+            phone_number_location: Some(vec![cell_phone_carrier]),
         };
         let result = DeviceLocation::saveToDb(&device_location, &conn);
         assert_eq!(result, Ok(()));

--- a/src/activities/facebook/facebook_last_location.rs
+++ b/src/activities/facebook/facebook_last_location.rs
@@ -19,27 +19,53 @@ pub struct Coordinate {
 #[allow(non_snake_case)]
 #[derive(Deserialize, Debug)]
 pub struct LastLocation {
-  pub last_location_v2: LastLocationObjects
+  pub last_location_v2: Option<LastLocationObjects>,
+  pub last_location: Option<LastLocationObjects>
 }
 
 #[allow(non_snake_case)]
 impl LastLocation {
     pub fn saveToDb(&self, conn: &Connection) -> Result<(), rusqlite::Error> {
-        conn.execute(
-            "INSERT INTO facebook_last_location (
-            time,
-            latitude,
-            longitude
-        )
-        VALUES (?1, ?2, ?3)",
-            params![
-                &self.last_location_v2.time.to_string(),
-                &self.last_location_v2.coordinate.latitude.to_string(),
-                &self.last_location_v2.coordinate.longitude.to_string()
-            ],
-        )
-        .map_err(|err| println!("{:?}", err))
-        .ok();
+        match &self.last_location_v2 {
+            None => None,
+            Some(x) => Some(
+                conn.execute(
+                    "INSERT INTO facebook_last_location (
+                        time,
+                        latitude,
+                        longitude
+                    )
+                    VALUES (?1, ?2, ?3)",
+                    params![
+                        &x.time.to_string(),
+                        &x.coordinate.latitude.to_string(),
+                        &x.coordinate.longitude.to_string()
+                    ],
+                )
+                .map_err(|err| println!("{:?}", err))
+                .ok(),
+            ),
+        };
+        match &self.last_location {
+            None => None,
+            Some(x) => Some(
+                conn.execute(
+                    "INSERT INTO facebook_last_location (
+                        time,
+                        latitude,
+                        longitude
+                    )
+                    VALUES (?1, ?2, ?3)",
+                    params![
+                        &x.time.to_string(),
+                        &x.coordinate.latitude.to_string(),
+                        &x.coordinate.longitude.to_string()
+                    ],
+                )
+                .map_err(|err| println!("{:?}", err))
+                .ok(),
+            ),
+        };
 
         Ok(())
     }
@@ -49,6 +75,26 @@ impl LastLocation {
 mod tests {
     use super::*;
     use rusqlite::Connection;
+
+    #[test]
+    fn test_last_l_v2() -> Result<(), Box<dyn std::error::Error>> {
+        let conn = Connection::open("ichnion.db")?;
+        let test_coordinate = Coordinate {
+            latitude: 10.0,
+            longitude: 10.0,
+        };
+        let test_last_location1 = LastLocationObjects {
+            time: 1,
+            coordinate: test_coordinate,
+        };
+        let test_last_location = LastLocation {
+            last_location_v2: Some(test_last_location1),
+            last_location: None,
+        };
+        let result = LastLocation::saveToDb(&test_last_location, &conn);
+        assert!(result == Ok(()));
+        Ok(())
+    }
 
     #[test]
     fn test_last_l() -> Result<(), Box<dyn std::error::Error>> {
@@ -62,7 +108,8 @@ mod tests {
             coordinate: test_coordinate,
         };
         let test_last_location = LastLocation {
-            last_location_v2: test_last_location1,
+            last_location_v2: None,
+            last_location: Some(test_last_location1),
         };
         let result = LastLocation::saveToDb(&test_last_location, &conn);
         assert!(result == Ok(()));

--- a/src/activities/facebook/facebook_location_history.rs
+++ b/src/activities/facebook/facebook_location_history.rs
@@ -10,7 +10,6 @@ pub struct LocationHistory {
     pub location_history: Option<Vec<FbLocationHistory>>
 }
 
-#[rustfmt::skip]
 #[derive(Deserialize, Debug)]
 pub struct FbLocationHistory {
     pub name: String,

--- a/src/activities/facebook/facebook_location_history.rs
+++ b/src/activities/facebook/facebook_location_history.rs
@@ -28,9 +28,8 @@ pub struct Coordinate {
 #[allow(non_snake_case)]
 impl LocationHistory {
     pub fn saveToDb(&self,conn: &Connection) -> Result<(), rusqlite::Error> {
-        match &self.location_history_v2 {
-            None => None,
-            Some(x) => Some (for elem in x.iter() {
+          match &self.location_history_v2 {
+            Some(x) => x.iter().for_each(|elem| {
                 conn.execute(
                     "INSERT into facebook_location_history
                     (time, name, latitude, longitude)
@@ -44,11 +43,11 @@ impl LocationHistory {
                 )
                 .map_err(|err| println!("{:?}", err))
                 .ok();
-            })
+            }),
+            None => println!("Old version of Facebook's data"),
         };
         match &self.location_history {
-            None => None,
-            Some(x) => Some (for elem in x.iter() {
+            Some(x) => x.iter().for_each(|elem| {
                 conn.execute(
                     "INSERT into facebook_location_history
                     (time, name, latitude, longitude)
@@ -62,13 +61,12 @@ impl LocationHistory {
                 )
                 .map_err(|err| println!("{:?}", err))
                 .ok();
-            })
+            }),
+            None => println!("Current version of Facebook's data"),
         };
-
         Ok(())
     }
 }
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/activities/facebook/primary_location.rs
+++ b/src/activities/facebook/primary_location.rs
@@ -6,7 +6,8 @@ use uuid::Uuid;
 #[allow(non_snake_case)]
 #[derive(Deserialize, Debug)]
 pub struct PrimaryLocation {
-  pub primary_location_v2: CityAndRegionAndZipcode
+  pub primary_location_v2: Option<CityAndRegionAndZipcode>,
+  pub primary_location: Option<CityAndRegionAndZipcode>
 }
 
 #[rustfmt::skip]
@@ -22,18 +23,41 @@ pub struct CityAndRegionAndZipcode {
 impl PrimaryLocation {
     pub fn saveToDb(&self, conn: &Connection) -> Result<(), rusqlite::Error> {
         let my_uuid = Uuid::new_v4();
-        conn.execute(
-            "INSERT into facebook_primary_location
-                (uuid, city_region_pairs, zipcode)
-                values(?1, $2, $3)",
-            params![
-                &my_uuid.to_string(),
-                &self.primary_location_v2.city_region_pairs[0][0],
-                &self.primary_location_v2.zipcode[0],
-            ],
-        )
-        .map_err(|err| println!("{:?}", err))
-        .ok();
+        match &self.primary_location_v2 {
+            None => None,
+            Some(x) => Some(
+                conn.execute(
+                    "INSERT into facebook_primary_location
+                                (uuid, city_region_pairs, zipcode)
+                                values(?1, $2, $3)",
+                    params![
+                        &my_uuid.to_string(),
+                        x.city_region_pairs[0][0],
+                        x.zipcode[0],
+                    ],
+                )
+                .map_err(|err| println!("{:?}", err))
+                .ok(),
+            ),
+        };
+
+        match &self.primary_location {
+            None => None,
+            Some(x) => Some(
+                conn.execute(
+                    "INSERT into facebook_primary_location
+                                (uuid, city_region_pairs, zipcode)
+                                values(?1, $2, $3)",
+                    params![
+                        &my_uuid.to_string(),
+                        x.city_region_pairs[0][0],
+                        x.zipcode[0],
+                    ],
+                )
+                .map_err(|err| println!("{:?}", err))
+                .ok(),
+            ),
+        };
         Ok(())
     }
 }
@@ -44,6 +68,22 @@ mod tests {
     use rusqlite::Connection;
 
     #[test]
+    fn test_primary_location_v2() -> Result<(), Box<dyn std::error::Error>> {
+        let conn = Connection::open("ichnion.db")?;
+        let zip_code = "1510053".to_string();
+        let city_region_zipcode = CityAndRegionAndZipcode {
+            city_region_pairs: vec![vec!["Tokyo".to_string(), "Shibuya".to_string()]],
+            zipcode: vec![zip_code],
+        };
+        let primary_location = PrimaryLocation {
+            primary_location_v2: Some(city_region_zipcode),
+            primary_location: None,
+        };
+        let result = PrimaryLocation::saveToDb(&primary_location, &conn);
+        assert_eq!(result, Ok(()));
+        Ok(())
+    }
+    #[test]
     fn test_primary_location() -> Result<(), Box<dyn std::error::Error>> {
         let conn = Connection::open("ichnion.db")?;
         let zip_code = "1510053".to_string();
@@ -52,11 +92,11 @@ mod tests {
             zipcode: vec![zip_code],
         };
         let primary_location = PrimaryLocation {
-            primary_location_v2: city_region_zipcode,
+            primary_location_v2: None,
+            primary_location: Some(city_region_zipcode),
         };
         let result = PrimaryLocation::saveToDb(&primary_location, &conn);
         assert_eq!(result, Ok(()));
         Ok(())
     }
 }
-

--- a/src/main.rs
+++ b/src/main.rs
@@ -164,8 +164,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
             let result: facebook_location_history::LocationHistory =
                 serde_json::from_str(&rawdata)?;
-            //println! ("({} records)", result.location_history_v2.len());
             let response = result.saveToDb(&conn)?;
+            println! ("({} records)", &result.location_history_v2.unwrap_or_default().len());
             println!("{:?}", response);
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -136,10 +136,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
             let response = result.saveToDb(&conn)?;
 
-            println!(
-                "( {} records )",
-                result.primary_location_v2.city_region_pairs.len()
-            );
+            println!("( 1 record )");
             println!("{:?}", response);
         } else if f_name.starts_with("primary_public_location.json") {
             println!("processing {}", d_name);
@@ -167,7 +164,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
             let result: facebook_location_history::LocationHistory =
                 serde_json::from_str(&rawdata)?;
-            println! ("({} records)", result.location_history_v2.len());
+            //println! ("({} records)", result.location_history_v2.len());
             let response = result.saveToDb(&conn)?;
             println!("{:?}", response);
         }


### PR DESCRIPTION
Fixes #43 
Fixes #44 
Fixes #42

Changes proposed in this pull request:
- I changed the type of different attributes to Option<>, as we don't know before executing the code if it is a former or a current version of Facebook data. 
- I changed the different Facebook location functions by adding a match method to manage the different versions of Facebook data (with or without _v2). I tried it on my data and it looks like it works. 
- I just added other issues that should have been fixed in the last pull request. This current pull request only concerns #42 


@ichnion/maintainer
